### PR TITLE
Improvements to Docker images

### DIFF
--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:14.04 as builder
 LABEL maintainer="info@reddcoin.com"
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -23,3 +23,17 @@ RUN ./autogen.sh && ./configure --without-gui
 
 RUN make
 RUN make install
+
+FROM ubuntu:14.04
+LABEL maintainer="info@reddcoin.com"
+
+RUN apt-get update \
+    && apt-get install -y git software-properties-common \
+    && add-apt-repository ppa:bitcoin/bitcoin \
+    && apt-get update \
+    && apt-get install -y libboost-all-dev libdb4.8-dev libdb4.8++-dev miniupnpc \
+    && apt-get purge -y software-properties-common \
+    && apt-get autoremove --yes \
+    && apt-get clean --yes
+
+COPY --from=builder /usr/local/bin/* /usr/local/bin/

--- a/seeder/Dockerfile
+++ b/seeder/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:stretch-slim as builder
 LABEL maintainer="info@reddcoin.com"
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -9,13 +9,14 @@ WORKDIR /src
 RUN git clone https://github.com/reddcoin-project/reddcoin-seeder.git
 
 RUN cd ./reddcoin-seeder && make
-RUN mv ./reddcoin-seeder/dnsseed /usr/local/bin
-RUN rm -rf reddcoin-seeder
 
-# Cleanup Build Packages
-RUN apt-get remove -y \
-  build-essential libboost-all-dev libssl-dev
-RUN apt-get autoremove -y
+FROM debian:stretch-slim
+LABEL maintainer="info@reddcoin.com"
+RUN apt-get update && apt-get install -y openssl \
+    && apt -y autoremove \
+    && apt -y clean
+
+COPY --from=builder /src/reddcoin-seeder/dnsseed /usr/local/bin
 
 EXPOSE 53/udp
 

--- a/tipbots/reddit/Dockerfile
+++ b/tipbots/reddit/Dockerfile
@@ -1,44 +1,18 @@
-FROM ubuntu:20.04
+FROM python:slim
 LABEL maintainer="info@reddcoin.com"
-ENV DEBIAN_FRONTEND=noninteractive
 
-WORKDIR /root
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git \
+  libmariadb-dev \
+  gcc \
+  && apt-get -y autoremove \
+  && apt-get -y clean
 
-# install system/build dependencies
-RUN apt -y update -qq \
-    && apt -y install -qq --no-install-recommends \
-        python3 \
-        python3-dev \
-        python3-pip \
-        python3-setuptools \
-        build-essential \
-        mysql-client \
-        libmysqlclient-dev \
-        wget \
-        sudo \
-        software-properties-common \
-        git \
-        zip \
-        unzip \
-    && apt -y autoremove \
-    && apt -y clean
-
-RUN pip3 install \
-    dateutils==0.6.7 \
-    irc==18.0.0 \
-    mysqlclient==1.4.6 \
-    praw==7.2.0 \
-    PyYAML==5.3 \
-    Jinja2==2.10.3
-    SQLAlchemy==1.3.12
-
-RUN pip3 install https://github.com/reddcoin-project/python-twitter-webhooks/archive/master.zip
-RUN pip3 install https://github.com/ryanmcgrath/twython/archive/master.zip
-
+COPY requirements.txt .
 ENV VERSION=0.1
-RUN  pip3 install https://github.com/dpifke/pifkoin/archive/master.zip
-
-# RUN git clone https://github.com/reddcoin-project/SocialTipBot
+RUN pip3 install -r requirements.txt
+WORKDIR /root
+RUN git clone https://github.com/reddcoin-project/SocialTipBot
 
 WORKDIR /root/SocialTipBot/src
 
@@ -46,4 +20,3 @@ EXPOSE 3000 3000
 
 CMD [ "./run.py"]
 ENTRYPOINT ["python3"]
-

--- a/tipbots/reddit/requirements.txt
+++ b/tipbots/reddit/requirements.txt
@@ -1,0 +1,11 @@
+dateutils==0.6.7
+irc==18.0.0
+mysqlclient==1.4.6
+praw==7.2.0
+PyYAML==5.3
+Jinja2==2.10.3
+SQLAlchemy==1.3.12
+git+https://github.com/reddcoin-project/python-twitter-webhooks.git
+git+https://github.com/ryanmcgrath/twython.git
+git+https://github.com/dpifke/pifkoin.git
+git+https://github.com/reddcoin-project/python-reddcoinrpc.git

--- a/tipbots/telegram/Dockerfile
+++ b/tipbots/telegram/Dockerfile
@@ -1,30 +1,14 @@
-FROM ubuntu:20.04
+FROM python:slim
 LABEL maintainer="info@reddcoin.com"
-ENV DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git \
+  && apt-get -y autoremove \
+  && apt-get -y clean
+
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
 WORKDIR /root
-
-# install system/build dependencies
-RUN apt -y update -qq \
-    && apt -y install -qq --no-install-recommends \
-        python3 \
-        python3-pip \
-        python3-dev \
-        build-essential \
-        git \
-    && apt -y autoremove \
-    && apt -y clean
-
-RUN pip3 install \
-    requests \
-    beautifulsoup4 \
-    pyqrcode \
-    Image \
-    pypng \
-    emoji \
-    apscheduler
-
-RUN pip3 install python-telegram-bot==12.0.0b1 --upgrade
 
 RUN git clone https://github.com/cryptoBUZE/reddbot-telegram
 
@@ -32,4 +16,3 @@ WORKDIR /root/reddbot-telegram
 
 CMD [ "./reddbot.py"]
 ENTRYPOINT ["python3"]
-

--- a/tipbots/telegram/requirements.txt
+++ b/tipbots/telegram/requirements.txt
@@ -1,0 +1,8 @@
+requests
+beautifulsoup4
+pyqrcode
+Image
+pypng
+emoji
+apscheduler
+python-telegram-bot==12.0.0b1 

--- a/tipbots/twitter/Dockerfile
+++ b/tipbots/twitter/Dockerfile
@@ -1,44 +1,18 @@
-FROM ubuntu:20.04
+FROM python:slim
 LABEL maintainer="info@reddcoin.com"
-ENV DEBIAN_FRONTEND=noninteractive
 
-WORKDIR /root
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git \
+  libmariadb-dev \
+  gcc \
+  && apt-get -y autoremove \
+  && apt-get -y clean
 
-# install system/build dependencies
-RUN apt -y update -qq \
-    && apt -y install -qq --no-install-recommends \
-        python3 \
-        python3-dev \
-        python3-pip \
-        python3-setuptools \
-        build-essential \
-        mysql-client \
-        libmysqlclient-dev \
-        wget \
-        sudo \
-        software-properties-common \
-        git \
-        zip \
-        unzip \
-    && apt -y autoremove \
-    && apt -y clean
-
-RUN pip3 install \
-    dateutils==0.6.7 \
-    irc==18.0.0 \
-    mysqlclient==1.4.6 \
-    praw==7.2.0 \
-    PyYAML==5.3 \
-    Jinja2==2.10.3
-    SQLAlchemy==1.3.12
-
-RUN pip3 install https://github.com/reddcoin-project/python-twitter-webhooks/archive/master.zip
-RUN pip3 install https://github.com/ryanmcgrath/twython/archive/master.zip
-
+COPY requirements.txt .
 ENV VERSION=0.1
-RUN  pip3 install https://github.com/dpifke/pifkoin/archive/master.zip
-
-# RUN git clone https://github.com/reddcoin-project/SocialTipBot
+RUN pip3 install -r requirements.txt
+WORKDIR /root
+RUN git clone https://github.com/reddcoin-project/SocialTipBot
 
 WORKDIR /root/SocialTipBot/src
 
@@ -46,4 +20,3 @@ EXPOSE 3000 3000
 
 CMD [ "./run.py"]
 ENTRYPOINT ["python3"]
-

--- a/tipbots/twitter/requirements.txt
+++ b/tipbots/twitter/requirements.txt
@@ -1,0 +1,11 @@
+dateutils==0.6.7
+irc==18.0.0
+mysqlclient==1.4.6
+praw==7.2.0
+PyYAML==5.3
+Jinja2==2.10.3
+SQLAlchemy==1.3.12
+git+https://github.com/reddcoin-project/python-twitter-webhooks.git
+git+https://github.com/ryanmcgrath/twython.git
+git+https://github.com/dpifke/pifkoin.git
+git+https://github.com/reddcoin-project/python-reddcoinrpc.git


### PR DESCRIPTION
Use multi-stage build where possible. Multi-stage build reduces the overall size of images and removes build dependencies from the runtime image.

Move python based images to a python docker image.
Implements requirements.txt for python-based images.
Fixes missing dependency for reddcoinrpc module in SocialTipBot image

